### PR TITLE
Sample rdaddr_r at the rising edge of bus_edge

### DIFF
--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -213,7 +213,7 @@ module top(
         wraddr_r <= extbus_a;
         wrdata_r <= extbus_d;
     end
-    always @(negedge bus_read) begin
+    always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;
     end
 


### PR DESCRIPTION
Fix for #4 and possibly #5 

This change moves sampling of the external address bus from the negative edge of bus_read to the positive edge. Implicit with this change is that the address bus is stable when CS# and/or RD# are asserted.

This change was validated against the emulator and all reads matched between the hardware and the emulator. This testing environment is somewhat slow due to the slow path setting the bits of the simulated bus over I2C which makes stress-testing this fix difficult. It should be validated on real hardware.