### PR TITLE
Fix sprite rendering priority

### DIFF
--- a/fpga/source/graphics/sprite_renderer.v
+++ b/fpga/source/graphics/sprite_renderer.v
@@ -319,8 +319,8 @@ module sprite_renderer(
     assign linebuf_wrdata = {linebuf_rddata[15:12] | sprite_collision_mask_r, 2'b0, sprite_z_r, cur_pixel_color};
 
     // Determine if current pixel should be rendered
-    assign target_pixel_is_transparent = (linebuf_rddata[7:0] == 8'b0);
-    wire render_pixel =  !pixel_is_transparent && sprite_z_r >= linebuf_rddata[9:8] && target_pixel_is_transparent;
+    wire dest_pixel_is_transparent = (linebuf_rddata[7:0] == 8'b0);
+	wire render_pixel = !pixel_is_transparent && ((sprite_z_r > linebuf_rddata[9:8]) || dest_pixel_is_transparent);
 
     // Determine collision for the current pixel
     wire [3:0] collision =

--- a/fpga/source/graphics/sprite_renderer.v
+++ b/fpga/source/graphics/sprite_renderer.v
@@ -319,7 +319,8 @@ module sprite_renderer(
     assign linebuf_wrdata = {linebuf_rddata[15:12] | sprite_collision_mask_r, 2'b0, sprite_z_r, cur_pixel_color};
 
     // Determine if current pixel should be rendered
-    wire render_pixel =  !pixel_is_transparent && sprite_z_r >= linebuf_rddata[9:8] && tmp_pixel_color != 0;
+    assign target_pixel_is_transparent = (linebuf_rddata[7:0] == 8'b0);
+    wire render_pixel =  !pixel_is_transparent && sprite_z_r >= linebuf_rddata[9:8] && target_pixel_is_transparent;
 
     // Determine collision for the current pixel
     wire [3:0] collision =


### PR DESCRIPTION
Fix for #10 : Don't overwrite existing pixel at same Z-depth.