### PR TITLE
Expose fifo empty status

### DIFF
--- a/doc/VERA Programmer's Reference.md
+++ b/doc/VERA Programmer's Reference.md
@@ -229,7 +229,7 @@ This document describes the **V**ersatile **E**mbedded **R**etro **A**dapter or 
 		<td>$1B</td>
 		<td>AUDIO_CTRL</td>
 		<td colspan="1" align="center">FIFO Full / FIFO Reset</td>
-		<td colspan="1" align="center">-</td>
+		<td colspan="1" align="center">FIFO Empty</td>
 		<td colspan="1" align="center">16-Bit</td>
 		<td colspan="1" align="center">Stereo</td>
 		<td colspan="4" align="center">PCM Volume</td>
@@ -723,6 +723,8 @@ For PCM playback, VERA contains a 4kB FIFO buffer. This buffer needs to be fille
 **16-bit** sets the data format to 16-bit. If this bit is 0, 8-bit data is expected.
 
 **FIFO Full** is a read-only flag that indicated if the FIFO is full. Any writes to the FIFO while this flag is 1 will be ignored. Writing a 1 to this register (**FIFO Reset**) will perform a FIFO reset, which will clear the contents of the FIFO buffer.
+
+**FIFO Empty** is a read-only flag that indicates the FIFO has completely drained and is no longer producing PCM audio.
 
 **PCM sample rate** controls the speed at which samples are read from the FIFO. A few example values:
 

--- a/fpga/source/audio/audio.v
+++ b/fpga/source/audio/audio.v
@@ -21,6 +21,7 @@ module audio(
     input  wire        fifo_write,
     output wire        fifo_full,
     output wire        fifo_almost_empty,
+    output wire        fifo_empty,
     
     // I2S audio output
     output wire        i2s_lrck,
@@ -73,6 +74,7 @@ module audio(
         .fifo_write(fifo_write),
         .fifo_full(fifo_full),
         .fifo_almost_empty(fifo_almost_empty),
+        .fifo_empty(fifo_empty),
 
         // Audio output
         .left_audio(pcm_left),

--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -18,6 +18,7 @@ module pcm(
     input  wire        fifo_write,
     output wire        fifo_full,
     output wire        fifo_almost_empty,
+    output wire        fifo_empty,
 
     // Audio output
     output wire [15:0] left_audio,
@@ -30,7 +31,6 @@ module pcm(
 
     wire [7:0] fifo_rddata;
     reg        fifo_read;
-    wire       fifo_empty;
 
     audio_fifo audio_fifo(
         .clk(clk),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -118,6 +118,7 @@ module top(
     wire [7:0] vram_rddata;
 
     wire       audio_fifo_low;
+    wire       audio_fifo_empty;
     wire       sprcol_irq;
     wire       vblank_pulse;
     wire       line_irq;
@@ -188,7 +189,7 @@ module top(
         5'h19: rddata = l1_vscroll_r[7:0];
         5'h1A: rddata = {4'b0, l1_vscroll_r[11:8]};
 
-        5'h1B: rddata = {audio_fifo_full, 1'b0, audio_mode_16bit_r, audio_mode_stereo_r, audio_pcm_volume_r};
+        5'h1B: rddata = {audio_fifo_full, audio_fifo_empty, audio_mode_16bit_r, audio_mode_stereo_r, audio_pcm_volume_r};
         5'h1C: rddata = audio_pcm_sample_rate_r;
         5'h1D: rddata = 8'h00;
 
@@ -213,7 +214,7 @@ module top(
         wraddr_r <= extbus_a;
         wrdata_r <= extbus_d;
     end
-    always @(negedge bus_read) begin
+    always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;
     end
 
@@ -1217,6 +1218,7 @@ module top(
         .fifo_write(audio_fifo_write_r),
         .fifo_full(audio_fifo_full),
         .fifo_almost_empty(audio_fifo_low),
+        .fifo_empty(audio_fifo_empty),
 
         // I2S audio output
         .i2s_lrck(audio_lrck),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -214,7 +214,7 @@ module top(
         wraddr_r <= extbus_a;
         wrdata_r <= extbus_d;
     end
-    always @(posedge bus_read) begin
+    always @(negedge bus_read) begin
         rdaddr_r <= extbus_a;
     end
 


### PR DESCRIPTION
This change fixes for issue #14 . The `fifo_empty` signal is plumbed up to top.v and placed in bit 6 of $1B.