### PR TITLE
Sample the address and data bus earlier during writes.

### DIFF
--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -209,9 +209,22 @@ module top(
     reg [4:0] rdaddr_r;
     reg [4:0] wraddr_r;
     reg [7:0] wrdata_r;
+    reg [4:0] wraddrp_r;
+    reg [7:0] wrdatap_r;
+    reg [4:0] wraddrn_r;
+    reg [7:0] wrdatan_r;
+
+    always @(posedge clk) begin
+        wraddrp_r <= extbus_a;
+        wrdatap_r <= extbus_d;
+    end
+    always @(negedge clk) begin
+        wraddrn_r <= extbus_a;
+        wrdatan_r <= extbus_d;
+    end
     always @(negedge bus_write) begin
-        wraddr_r <= extbus_a;
-        wrdata_r <= extbus_d;
+        wraddr_r <= clk ? wraddrn_r : wraddrp_r;
+        wrdata_r <= clk ? wrdatan_r : wrdatap_r;
     end
     always @(negedge bus_read) begin
         rdaddr_r <= extbus_a;


### PR DESCRIPTION
With this change, X16 is able to boot with a W65C816S at 8MHz. This fixes issue #15 .

A simple 2-entry "circular fifo" (if we can call it that) samples the address and data bus on the rising and falling edges of VERA's 25MHz clock. When `bus_write` is deasserted, the data latched into the oldest entry in the fifo is used instead of the data currently on the bus. This appears to be needed because the iCE40 has a 2-4 ns pad delay on many (all?) pads, and the `extbus_wr_n` signal is already delayed 8-10ns due to propagation delays of the 74xx logic and wire capacitance.

This also fixes an issue capturing A2 and A4 on small form factor X16 boards which have short, low capacitance address wires. For reasons I only partially understand, this only affects A2 and A4. (The issue can be fixed on these boards by adding a small load capacitor, 20-30pF, to A2 and A4.)

I'm not sure I am confident with the strategy used with this fix, but of the 10-12 different methods of working around this problem that I came up with and tested, this is the only one that survived every stress test without failure on both 65C02 and 65C816.