### PR TITLE
Implemented composite vblank irq fix for #7 from akumanatt.

### DIFF
--- a/fpga/source/video/video_composite.v
+++ b/fpga/source/video/video_composite.v
@@ -118,7 +118,7 @@ module video_composite(
     assign current_field = current_field_r;
 
 
-    assign vblank_pulse  = h_last && (vcnt == 524 || vcnt == 1049);
+    assign vblank_pulse  = h_half_line_last && (vcnt == 524 || vcnt == 1049);
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin


### PR DESCRIPTION
Fix for #7. VBLANK interrupts were missed for even frames in interlaced mode. This caused timing issues in several games and demos, and severely affected the X16 port of Super Mario Bros:

![IMG_20220925_120644005](https://user-images.githubusercontent.com/326088/192164742-d5bccb62-986f-479e-9a15-9f57b2e9c8c3.jpg)

These artifacts were resolved after VERA was updating with this fix.