### PR TITLE
Interlaced line irq fix; signal name error in IEN register fixed

### DIFF
--- a/fpga/source/graphics/composer.v
+++ b/fpga/source/graphics/composer.v
@@ -101,7 +101,7 @@ module composer(
         end else begin
             line_irq <= display_next_line && (
                 (!interlaced && y_counter_r == irqline) ||
-                ( interlaced && y_counter_r[8:1] == irqline[8:1]));
+                ( interlaced && y_counter_r[9:1] == {1'b0, irqline[8:1]}));
         end
     end
 
@@ -179,7 +179,7 @@ module composer(
                     scaled_x_counter_r <= scaled_x_counter_r + frac_x_incr_int;
                 end
             end
-            
+
             if (display_next_line) begin
                 scaled_x_counter_r <= 0;
             end

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -141,7 +141,7 @@ module top(
         5'h04: rddata = vram_data1_r;
         5'h05: rddata = {6'b0, dc_select_r, vram_addr_select_r};
 
-        5'h06: rddata = {irqline[8], scanline[8], 2'b0, irq_enable_audio_fifo_low_r, irq_enable_sprite_collision_r, irq_enable_line_r, irq_enable_vsync_r};
+        5'h06: rddata = {irq_line_r[8], scanline[8], 2'b0, irq_enable_audio_fifo_low_r, irq_enable_sprite_collision_r, irq_enable_line_r, irq_enable_vsync_r};
         5'h07: rddata = {sprite_collisions,   audio_fifo_low,              irq_status_sprite_collision_r, irq_status_line_r, irq_status_vsync_r};
         5'h08: rddata = scanline[7:0];
 


### PR DESCRIPTION
Fix for #26, line IRQs were firing twice in interlace mode because the counter width being compared was incorrect.

Also a fix for a signal name error in the IEN register. Not sure how I let that slip through - Radiant sees it as an error.