### PR TITLE
Multibyte write and copy

### DIFF
--- a/doc/VERA Programmer's Reference.md
+++ b/doc/VERA Programmer's Reference.md
@@ -1,6 +1,6 @@
 # VERA Programmer's Reference
 
-Version 0.9
+Version 0.10
 
 _Author: Frank van den Hoef_
 
@@ -311,7 +311,7 @@ Setting the **DECR** bit, will decrement instead of increment by the value set b
 
 ### Multibyte write and copy
 
-By setting the **Write pattern** the way bytes are written to VRAM is changed. The default mode (both bits set to 0) is that only _one_ VRAM byte is changed once a byte is written to DATA0 or DATA1. When the **Write pattern** is set differently multiple bytes (normally with the same value) are written to VRAM at the same time.
+The number of bytes that are written at once to VRAM can be changed by setting the two bits in **Write pattern**. In the default mode (both bits set to 0) only _one_ VRAM byte is changed when a byte is written to DATA0 or DATA1. This is the byte that exactly corresponds to the address written to. When the **Write pattern** is set differently multiple bytes (normally with the same value) are written to VRAM at the same time.
 
 Up to 4 bytes can be written to VRAM at once, aligned to a 32-bit address. Which of the 4 bytes are overwritten can be controlled: all possible patterns of bytes written to VRAM can be set by combining the 2 bits of **Write pattern** and the lower 2 bits of the address that is written to. Only the pattern that writes _nothing_ to VRAM cannot be set. 
 
@@ -367,19 +367,18 @@ Below is the mapping:
 
 #### Blitting
 
-A special combination of address and the 2 bits is used to signify **copying** of 4 bytes at the same time (aka "blitting"). This is when address % 4 == 0 and the 2-bit pattern is 11b. This works as follows:
+A special combination of the lower 2 bits of the address and the 2 bits in **Write pattern** is used to signify **copying** of (up to) 4 bytes at the same time (aka "blitting"). This is when address % 4 == 0 and the 2-bit pattern is 11b. This works as follows:
 
-
-1. Whenever there is a **read** from DATA0 or DATA1 (and this "blit-setting" is the case) an internal **32-bit cache** is filled with the (aligned 32-bit) value of DATA0 or DATA1. 
-2. Whenever there is a **write** or value 0 to DATA0 or DATA1 (and this "blit-setting" is the case)  this stored 32-bit cache is written to the VRAM address.
+1. Whenever there is a **read** from DATA0 or DATA1 (and this "blit-setting" is the case) an internal **32-bit cache** is filled with the 32-bit value at VRAM address ADDR0 or ADDR1 (aligned to 32-bit). 
+2. Whenever there is a **write** of value 0 to DATA0 or DATA1 (and this "blit-setting" is the case) this stored 32-bit cache is written to the VRAM address ADDR0 or ADDR1 (aligned to 32-bit).
 
 This effectively allows for copying 4 bytes _at the same time_ from VRAM to VRAM.
 
 #### Masked blitting
 
-It is also possible to blit _parts_ of the 32-bit cache. The value written to VERA (using a `sta DATA0` or `sta DATA1` in the above step 2) is used as an inverted nibble mask. 
+It is also possible to blit _parts_ of the 32-bit cache. The value written to VERA (using a `sta DATA0` or `sta DATA1` in the above step 2) is namely used as an inverted nibble mask. For example: writing the value `11000011b` to DATA0 in blit mode will mean that only the two middle bytes of a 32-bit value are copied.
 
-Setting a bit to 0 will make sure the corresponding nibble will be copied. Setting a bit to 1 will let a nibble be untouched during the blit. The Least Significant Bit (LSB) will affect the nibble with the lowest VRAM address (the left most pixel on screen) and the MSB will affect the nibble with the highest VRAM address (the right most pixel on screen).
+Setting a bit to 0 in this inverted mask will make sure the corresponding nibble _will_ be copied. Setting a bit to 1 will let a nibble be _untouched_ during the blit. The Least Significant Bit (LSB) will affect the nibble with the lowest VRAM address (the left most pixel) and the MSB will affect the nibble with the highest VRAM address (the right most pixel).
 
 **Note**: the above feature (multibyte writing and copying) is limited to main Video RAM: $00000-$1F9BF
 

--- a/fpga/source/main_ram.v
+++ b/fpga/source/main_ram.v
@@ -6,7 +6,7 @@ module main_ram(
     // Slave bus interface
     input  wire [14:0] bus_addr,
     input  wire [31:0] bus_wrdata,
-    input  wire  [3:0] bus_wrbytesel,
+    input  wire  [7:0] bus_wrnibblesel,
     output reg  [31:0] bus_rddata,
     input  wire        bus_write);
 
@@ -32,31 +32,55 @@ module main_ram(
 
     always @(posedge clk) begin
         if (bus_write && blk10_cs) begin
-            if (bus_wrbytesel[0]) begin
-                blk10[bus_addr][7:0] = bus_wrdata[7:0];
+            if (bus_wrnibblesel[0]) begin
+                blk10[bus_addr][3:0] = bus_wrdata[3:0];
             end
-            if (bus_wrbytesel[1]) begin
-                blk10[bus_addr][15:8] = bus_wrdata[15:8];
+            if (bus_wrnibblesel[1]) begin
+                blk10[bus_addr][7:4] = bus_wrdata[7:4];
             end
-            if (bus_wrbytesel[2]) begin
-                blk10[bus_addr][23:16] = bus_wrdata[23:16];
+            if (bus_wrnibblesel[2]) begin
+                blk10[bus_addr][11:8] = bus_wrdata[11:8];
             end
-            if (bus_wrbytesel[3]) begin
-                blk10[bus_addr][31:24] = bus_wrdata[31:24];
+            if (bus_wrnibblesel[3]) begin
+                blk10[bus_addr][15:12] = bus_wrdata[15:12];
+            end
+            if (bus_wrnibblesel[4]) begin
+                blk10[bus_addr][19:16] = bus_wrdata[19:16];
+            end
+            if (bus_wrnibblesel[5]) begin
+                blk10[bus_addr][23:20] = bus_wrdata[23:20];
+            end
+            if (bus_wrnibblesel[6]) begin
+                blk10[bus_addr][27:24] = bus_wrdata[27:24];
+            end
+            if (bus_wrnibblesel[7]) begin
+                blk10[bus_addr][31:28] = bus_wrdata[31:28];
             end
         end
         if (bus_write && blk32_cs) begin
-            if (bus_wrbytesel[0]) begin
-                blk32[bus_addr][7:0] = bus_wrdata[7:0];
+            if (bus_wrnibblesel[0]) begin
+                blk32[bus_addr][3:0] = bus_wrdata[3:0];
             end
-            if (bus_wrbytesel[1]) begin
-                blk32[bus_addr][15:8] = bus_wrdata[15:8];
+            if (bus_wrnibblesel[1]) begin
+                blk32[bus_addr][7:4] = bus_wrdata[7:4];
             end
-            if (bus_wrbytesel[2]) begin
-                blk32[bus_addr][23:16] = bus_wrdata[23:16];
+            if (bus_wrnibblesel[2]) begin
+                blk32[bus_addr][11:8] = bus_wrdata[11:8];
             end
-            if (bus_wrbytesel[3]) begin
-                blk32[bus_addr][31:24] = bus_wrdata[31:24];
+            if (bus_wrnibblesel[3]) begin
+                blk32[bus_addr][15:12] = bus_wrdata[15:12];
+            end
+            if (bus_wrnibblesel[4]) begin
+                blk32[bus_addr][19:16] = bus_wrdata[19:16];
+            end
+            if (bus_wrnibblesel[5]) begin
+                blk32[bus_addr][23:20] = bus_wrdata[23:20];
+            end
+            if (bus_wrnibblesel[6]) begin
+                blk32[bus_addr][27:24] = bus_wrdata[27:24];
+            end
+            if (bus_wrnibblesel[7]) begin
+                blk32[bus_addr][31:28] = bus_wrdata[31:28];
             end
         end
 
@@ -86,7 +110,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[15:0]),
         .DO(blk10_rddata[15:0]),
-        .MASKWE({{2{bus_wrbytesel[1]}}, {2{bus_wrbytesel[0]}}}),
+        .MASKWE(bus_wrnibblesel[3:0]),
         .WE(bus_write && blk10_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -98,7 +122,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[31:16]),
         .DO(blk10_rddata[31:16]),
-        .MASKWE({{2{bus_wrbytesel[3]}}, {2{bus_wrbytesel[2]}}}),
+        .MASKWE(bus_wrnibblesel[7:4]),
         .WE(bus_write && blk10_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -110,7 +134,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[15:0]),
         .DO(blk32_rddata[15:0]),
-        .MASKWE({{2{bus_wrbytesel[1]}}, {2{bus_wrbytesel[0]}}}),
+        .MASKWE(bus_wrnibblesel[3:0]),
         .WE(bus_write && blk32_cs),
         .CS(1'b1),
         .STDBY(1'b0),
@@ -122,7 +146,7 @@ module main_ram(
         .AD(bus_addr[13:0]),
         .DI(bus_wrdata[31:16]),
         .DO(blk32_rddata[31:16]),
-        .MASKWE({{2{bus_wrbytesel[3]}}, {2{bus_wrbytesel[2]}}}),
+        .MASKWE(bus_wrnibblesel[7:4]),
         .WE(bus_write && blk32_cs),
         .CS(1'b1),
         .STDBY(1'b0),

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -272,8 +272,6 @@ module top(
         4'hF: increment = 'd640;
     endcase
 
-    reg [16:0] ib_addr_tmp;
-
     reg [16:0] ib_addr_r,      ib_addr_next;
     reg  [1:0] ib_wrpattern_r, ib_wrpattern_next;
     reg [31:0] ib_cache32_r,   ib_cache32_next;

--- a/fpga/source/vram_if.v
+++ b/fpga/source/vram_if.v
@@ -5,8 +5,8 @@ module vram_if(
 
     // Interface 0 - 8-bit (highest priority)
     input  wire [16:0] if0_addr,
-	input  wire  [1:0] if0_wrpattern,
-	input  wire [31:0] if0_cache32,
+    input  wire  [1:0] if0_wrpattern,
+    input  wire [31:0] if0_cache32,
     input  wire  [7:0] if0_wrdata,
     output wire  [7:0] if0_rddata,
     output wire [31:0] if0_rddata32,
@@ -56,46 +56,46 @@ module vram_if(
     reg if2_ack_next;
     reg if3_ack_next;
 
-	assign ram_wrdata = ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) ? if0_cache32 : {4{if0_wrdata}};
+    assign ram_wrdata = ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) ? if0_cache32 : {4{if0_wrdata}};
     assign ram_write  = if0_strobe && if0_write;
 
-	/*
-		Colums: address % 4
-		Rows: 2-bit value representing a pattern (but dependent on addrss, so we can create all possible patterns)
-	
-		_   0    1    2    3
-		00 0001 0010 0100 1000
-		01 0011 0110 1100 1001
-		10 0101 1010 0111 1110
-		11 1111 1111 1101 1011
+    /*
+        Colums: address % 4
+        Rows: 2-bit value representing a pattern (but dependent on addrss, so we can create all possible patterns)
+    
+        _   0    1    2    3
+        00 0001 0010 0100 1000
+        01 0011 0110 1100 1001
+        10 0101 1010 0111 1110
+        11 1111 1111 1101 1011
 
-	*/
+    */
 
     always @* case (if0_wrpattern[1:0])
-		2'b00: case (if0_addr[1:0])
-			2'b00: ram_wrbytesel = 4'b0001;
-			2'b01: ram_wrbytesel = 4'b0010;
-			2'b10: ram_wrbytesel = 4'b0100;
-			2'b11: ram_wrbytesel = 4'b1000;
-		endcase
-		2'b01: case (if0_addr[1:0])
-			2'b00: ram_wrbytesel = 4'b0011;
-			2'b01: ram_wrbytesel = 4'b0110;
-			2'b10: ram_wrbytesel = 4'b1100;
-			2'b11: ram_wrbytesel = 4'b1001;
-		endcase
-		2'b10: case (if0_addr[1:0])
-			2'b00: ram_wrbytesel = 4'b0101;
-			2'b01: ram_wrbytesel = 4'b1010;
-			2'b10: ram_wrbytesel = 4'b0111;
-			2'b11: ram_wrbytesel = 4'b1110;
-		endcase
-		2'b11: case (if0_addr[1:0])
-			2'b00: ram_wrbytesel = 4'b1111; // blit
-			2'b01: ram_wrbytesel = 4'b1111;
-			2'b10: ram_wrbytesel = 4'b1101;
-			2'b11: ram_wrbytesel = 4'b1011;
-		endcase
+        2'b00: case (if0_addr[1:0])
+            2'b00: ram_wrbytesel = 4'b0001;
+            2'b01: ram_wrbytesel = 4'b0010;
+            2'b10: ram_wrbytesel = 4'b0100;
+            2'b11: ram_wrbytesel = 4'b1000;
+        endcase
+        2'b01: case (if0_addr[1:0])
+            2'b00: ram_wrbytesel = 4'b0011;
+            2'b01: ram_wrbytesel = 4'b0110;
+            2'b10: ram_wrbytesel = 4'b1100;
+            2'b11: ram_wrbytesel = 4'b1001;
+        endcase
+        2'b10: case (if0_addr[1:0])
+            2'b00: ram_wrbytesel = 4'b0101;
+            2'b01: ram_wrbytesel = 4'b1010;
+            2'b10: ram_wrbytesel = 4'b0111;
+            2'b11: ram_wrbytesel = 4'b1110;
+        endcase
+        2'b11: case (if0_addr[1:0])
+            2'b00: ram_wrbytesel = 4'b1111; // blit
+            2'b01: ram_wrbytesel = 4'b1111;
+            2'b10: ram_wrbytesel = 4'b1101;
+            2'b11: ram_wrbytesel = 4'b1011;
+        endcase
 
     endcase
 
@@ -149,7 +149,7 @@ module vram_if(
     always @(posedge clk) begin
         if (if0_ack) begin
             if0_rddata8_r <= if0_rddata8;
-			if0_rddata32_r <= ram_rddata;
+            if0_rddata32_r <= ram_rddata;
         end
     end
 

--- a/fpga/source/vram_if.v
+++ b/fpga/source/vram_if.v
@@ -5,6 +5,7 @@ module vram_if(
 
     // Interface 0 - 8-bit (highest priority)
     input  wire [16:0] if0_addr,
+	input  wire  [1:0] if0_wrpattern,
     input  wire  [7:0] if0_wrdata,
     output wire  [7:0] if0_rddata,
     input  wire        if0_strobe,
@@ -56,11 +57,44 @@ module vram_if(
     assign ram_wrdata = {4{if0_wrdata}};
     assign ram_write  = if0_strobe && if0_write;
 
-    always @* case (if0_addr[1:0])
-        2'b00: ram_wrbytesel = 4'b0001;
-        2'b01: ram_wrbytesel = 4'b0010;
-        2'b10: ram_wrbytesel = 4'b0100;
-        2'b11: ram_wrbytesel = 4'b1000;
+	/*
+		Colums: address % 4
+		Rows: 2-bit value representing a pattern (but dependent on addrss, so we can create all possible patterns)
+	
+		_   0    1    2    3
+		00 0001 0010 0100 1000
+		01 0011 0110 1100 1001
+		10 0101 1010 0111 1110
+		11 1111 1111 1101 1011
+
+	*/
+
+    always @* case (if0_wrpattern[1:0])
+		2'b00: case (if0_addr[1:0])
+			2'b00: ram_wrbytesel = 4'b0001;
+			2'b01: ram_wrbytesel = 4'b0010;
+			2'b10: ram_wrbytesel = 4'b0100;
+			2'b11: ram_wrbytesel = 4'b1000;
+		endcase
+		2'b01: case (if0_addr[1:0])
+			2'b00: ram_wrbytesel = 4'b0011;
+			2'b01: ram_wrbytesel = 4'b0110;
+			2'b10: ram_wrbytesel = 4'b1100;
+			2'b11: ram_wrbytesel = 4'b1001;
+		endcase
+		2'b10: case (if0_addr[1:0])
+			2'b00: ram_wrbytesel = 4'b0101;
+			2'b01: ram_wrbytesel = 4'b1010;
+			2'b10: ram_wrbytesel = 4'b0111;
+			2'b11: ram_wrbytesel = 4'b1110;
+		endcase
+		2'b11: case (if0_addr[1:0])
+			2'b00: ram_wrbytesel = 4'b1111; // blit
+			2'b01: ram_wrbytesel = 4'b1111;
+			2'b10: ram_wrbytesel = 4'b1101;
+			2'b11: ram_wrbytesel = 4'b1011;
+		endcase
+
     endcase
 
     always @* begin

--- a/fpga/source/vram_if.v
+++ b/fpga/source/vram_if.v
@@ -133,19 +133,13 @@ module vram_if(
     always @(posedge clk) if0_addr_r <= if0_addr[1:0];
 
 	// Cache for blitting
-    reg [31:0] if0_rddata32;
     reg [31:0] if0_rddata32_r;
 
     // Memory bus read data selection
     reg [7:0] if0_rddata8;
     reg [7:0] if0_rddata8_r;
     always @* case (if0_addr_r)
-        2'b00: begin
-			if0_rddata8 = ram_rddata[7:0];
-			if ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) begin
-				if0_rddata32 = ram_rddata;         // saving to-be-blit data into register
-			end
-		end
+        2'b00: if0_rddata8 = ram_rddata[7:0];
         2'b01: if0_rddata8 = ram_rddata[15:8];
         2'b10: if0_rddata8 = ram_rddata[23:16];
         2'b11: if0_rddata8 = ram_rddata[31:24];
@@ -154,7 +148,9 @@ module vram_if(
     always @(posedge clk) begin
         if (if0_ack) begin
             if0_rddata8_r <= if0_rddata8;
-			if0_rddata32_r <= if0_rddata32;         // keeping to-be-blit data into register
+            if ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) begin
+                if0_rddata32_r <= ram_rddata;
+            end
         end
     end
 

--- a/fpga/source/vram_if.v
+++ b/fpga/source/vram_if.v
@@ -54,7 +54,7 @@ module vram_if(
     reg if2_ack_next;
     reg if3_ack_next;
 
-    assign ram_wrdata = {4{if0_wrdata}};
+	assign ram_wrdata = ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) ? if0_rddata32_r : {4{if0_wrdata}};
     assign ram_write  = if0_strobe && if0_write;
 
 	/*
@@ -132,11 +132,20 @@ module vram_if(
     reg [1:0] if0_addr_r;
     always @(posedge clk) if0_addr_r <= if0_addr[1:0];
 
+	// Cache for blitting
+    reg [31:0] if0_rddata32;
+    reg [31:0] if0_rddata32_r;
+
     // Memory bus read data selection
     reg [7:0] if0_rddata8;
     reg [7:0] if0_rddata8_r;
     always @* case (if0_addr_r)
-        2'b00: if0_rddata8 = ram_rddata[7:0];
+        2'b00: begin
+			if0_rddata8 = ram_rddata[7:0];
+			if ((if0_wrpattern[1:0] == 2'b11) && (if0_addr[1:0] == 2'b00)) begin
+				if0_rddata32 = ram_rddata;         // saving to-be-blit data into register
+			end
+		end
         2'b01: if0_rddata8 = ram_rddata[15:8];
         2'b10: if0_rddata8 = ram_rddata[23:16];
         2'b11: if0_rddata8 = ram_rddata[31:24];
@@ -145,6 +154,7 @@ module vram_if(
     always @(posedge clk) begin
         if (if0_ack) begin
             if0_rddata8_r <= if0_rddata8;
+			if0_rddata32_r <= if0_rddata32;         // keeping to-be-blit data into register
         end
     end
 


### PR DESCRIPTION
-- _This feature has been made possible due to the help of many others on the X16 discord channel, most notably: **MooingLemur, Xark, Wavicle (jburks)** and **Yazarchy**. Many thanks to them!_ --

### Writing and copying multiple bytes at once

This change allows for multibyte writing and copying of VRAM data. Its main purpose is to increase performance.

### Register usage

This features uses two unused bits: Bit 1 and 2 of the ADDRx_H register, called **Write pattern**.

<table>
	<tr>
		<th>Addr</th>
		<th>Name</th>
		<th>Bit&nbsp;7</th>
		<th>Bit&nbsp;6</th>
		<th>Bit&nbsp;5 </th>
		<th>Bit&nbsp;4</th>
		<th>Bit&nbsp;3 </th>
		<th>Bit&nbsp;2</th>
		<th>Bit&nbsp;1 </th>
		<th>Bit&nbsp;0</th>
	</tr>
	<tr>
		<td>$02</td>
		<td>ADDRx_H (x=ADDRSEL)</td>
		<td colspan="4" align="center">Address Increment</td>
		<td colspan="1" align="center">DECR</td>
		<td colspan="2" align="center">Write pattern</td>
		<td colspan="1" align="center">VRAM Address (16)</td>
	</tr>
</table>

### How it works

The number of bytes that are written at once to VRAM can be changed by setting the two bits in **Write pattern**. In the default mode (both bits set to 0) only _one_ VRAM byte is changed when a byte is written to DATA0 or DATA1. This is the byte that exactly corresponds to the address written to. When the **Write pattern** is set differently multiple bytes (normally with the same value) are written to VRAM at the same time.

Up to 4 bytes can be written to VRAM at once, aligned to a 32-bit address. Which of the 4 bytes are overwritten can be controlled: all possible patterns of bytes written to VRAM can be set by combining the 2 bits of **Write pattern** and the lower 2 bits of the address that is written to. Only the pattern that writes _nothing_ to VRAM cannot be set. 

Below is the mapping:

<table>
    <thead>
        <tr>
            <th colspan="2" rowspan="2"></th>
            <th colspan="5">address % 4</th>
        </tr>
        <tr>
            <th>0</th>
            <th>1</th>
            <th>2</th>
            <th>3</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan=4><b>bits 1 and 2</b><br/>($9F22)</td>
            <td><b>00</b></td>
            <td>+---</td>
            <td>-+--</td>
            <td>--+-</td>
            <td>---+</td>
        </tr>
        <tr>
            <td><b>01</b></td>
            <td>++++</td>
            <td>-+-+</td>
            <td>+-+-</td>
            <td>++--</td>
        </tr>
        <tr>
            <td><b>10</b></td>
            <td><b>tr. blit</b></td>
            <td>++-+</td>
            <td>+++-</td>
            <td>-++-</td>
        </tr>
        <tr>
            <td><b>11</b></td>
            <td><b>blit</b></td>
            <td>+-++</td>
            <td>-+++</td>
            <td>--++</td>
        </tr>
    </tbody>
</table>

<!--
<table>
    <thead>
        <tr>
            <th colspan="2" rowspan="2"></th>
            <th colspan="5">address % 4</th>
        </tr>
        <tr>
            <th>0</th>
            <th>1</th>
            <th>2</th>
            <th>3</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan=4><b>bits 1 and 2</b><br/>($9F22)</td>
            <td><b>00</b></td>
            <td>+---</td>
            <td>-+--</td>
            <td>--+-</td>
            <td>---+</td>
        </tr>
        <tr>
            <td><b>01</b></td>
            <td>-+-+</td>
            <td>+-+-</td>
            <td>++--</td>
            <td>+--+</td>
        </tr>
        <tr>
            <td><b>10</b></td>
            <td>++++</td>
            <td>+++-</td>
            <td>-++-</td>
            <td>++-+</td>
        </tr>
        <tr>
            <td><b>11</b></td>
            <td><b>blit</b></td>
            <td>-+++</td>
            <td>--++</td>
            <td>+-++</td>
        </tr>
    </tbody>
</table>
-->

**FIXME** Update the text below to the new pattern layout!

**Note**: Each byte pattern is consists of four +'s and -'s. Each - or + represents a _byte_ in VRAM. A + means the byte is written to and a - means the byte in VRAM is untouched.

#### Blitting

A special combination of the lower 2 bits of the address and the 2 bits in **Write pattern** is used to signify **copying** of (up to) 4 bytes at the same time (aka "blitting"). This is when address % 4 == 0 and the 2-bit pattern is 11b. This works as follows:

1. Whenever there is a **read** from DATA0 or DATA1 (and this "blit-setting" is the case) an internal **32-bit cache** is filled with the 32-bit value at VRAM address ADDR0 or ADDR1 (aligned to 32-bit). 
2. Whenever there is a **write** of value 0 to DATA0 or DATA1 (and this "blit-setting" is the case) this stored 32-bit cache is written to the VRAM address ADDR0 or ADDR1 (aligned to 32-bit).

This effectively allows for copying 4 bytes _at the same time_ from VRAM to VRAM.

#### Masked blitting

It is also possible to blit _parts_ of the 32-bit cache. The value written to VERA (using a `sta DATA0` or `sta DATA1` in the above step 2) is namely used as an inverted nibble mask. For example: writing the value `11000011b` to DATA0 in blit mode will mean that only the two middle bytes of a 32-bit value are copied.

Setting a bit to 0 in this inverted mask will make sure the corresponding nibble _will_ be copied. Setting a bit to 1 will let a nibble be _untouched_ during the blit. The Least Significant Bit (LSB) will affect the nibble with the lowest VRAM address (the left most pixel) and the MSB will affect the nibble with the highest VRAM address (the right most pixel).

**Note**: the above feature (multibyte writing and copying) is limited to main Video RAM: $00000-$1F9BF

### Example code

In effect you can write 4 bytes of VRAM at the same time using a single 6502 `sta` command (after you setup the registers correctly):

```
lda #0          ; Set address to % 4 == 0
sta $9F20
lda #0
sta $9F21

lda #%00110100  ; Set increment to 4 and bits 1 and 2 to 10b
sta $9F22

lda #42
sta DATA0       ; Write color value 4 bytes at a time
sta DATA0
sta DATA0
sta DATA0
sta DATA0
sta DATA0
...
```
To copy VRAM to VRAM quickly you can do use an `lda` and `sta` (with a "blit-setting" configured):

```
lda #0          ; Set address to % 4 == 0
sta $9F20
sta $9F21

lda #%00110110  ; Set increment to 4 and bits 1 and 2 to 11b
sta $9F22

lda DATA1       ; Copy 4 bytes at a time
stz DATA0       ; Writing a 0 during the blit will do a full blit (all 8 nibbles)
lda DATA1
stz DATA0
lda DATA1
stz DATA0
lda DATA1
stz DATA0
lda DATA1
...
```

### Use cases

Here are a few use cases:

- Writing 4 bytes at the time (_pattern_: ++++)
  - Clearing a bitmap screen 4 times as fast
  - Drawing (large) polygons much faster
- Writing 2-3  consecutive bytes at the same time (_patterns_: ++--, -++-, --++, +++-, -+++)
  - Drawing multiple (textured) pixel columns at the same time
    - In essence: just like deferred column rendering in DOOM and Wolfenstein 3D worked.
- Drawing non-consecutive 2 bytes at the same time (_patterns_: +-+-, -+-+)
  - Updating tile attributes (which are spaced 2 bytes apart) more quickly
- Copying 4 bytes of data from VRAM to VRAM (_blit_)
  - Copying tiledata 4 times as fast (for tile animations)
  - Copying bitmap data 4 times as fast
- Partial copying of up to 4 bytes from VRAM to VRAM (_masked blit_)
  - Copying an image with a transparency mask map
  - Drawing pseudo random dithering pixels

This shows the speed difference (on real HW) of filling/clearing the screen [(source):](https://github.com/visual-trials/X16-Hardware-Tests/blob/master/special_tests/multibyte_writes.s)

![Clearing screen 1 byte per write](https://user-images.githubusercontent.com/17767704/214688623-21301977-f661-46d2-8700-625172e45020.jpg)
![Clearing screen 4 bytes per write](https://user-images.githubusercontent.com/17767704/214688369-eef8adba-ee4e-43df-a704-11e5a14f727e.jpg)

This show the speed difference (on real HW) of copying bitmap data [(source):](https://github.com/visual-trials/X16-Hardware-Tests/blob/master/special_tests/multibyte_blits.s)

![Copy bitmap 1 byte per copy](https://user-images.githubusercontent.com/17767704/214688490-dab31e16-4477-48c2-8b94-23d98c5144bf.jpg)
![Copy bitmap 4 bytes per copy](https://user-images.githubusercontent.com/17767704/214688520-07eae75e-6105-4672-8866-6955d1a403a3.jpg)

### Backwards compatibility and HW testing

This feature uses 2 bits that were previously unused. If set to 00b it is completely backwards compatible, since it will do basic 1 byte writes to VRAM. Only if the bits are set differently will the behaviour change of VERA.

This features has been tested for backwards compatability for the following X16 application/demos/games:

| Application/Demo/Game | Tested by |
| ----------- | ----------- |
| X16 Hardware Tester | JeffreyH |
| X16 Kernal / Basic | JeffreyH |
| Super Mario Bros (X16 port) | JeffreyH |
| STNICCC demo | JeffreyH |
| Wolf3D demo | JeffreyH |
| ... | ... |
| ... | ... |
| ... | ... |

These all work as expected. This is a good indication that this feature is indeed backwards compatible and most if not all software / demos / games have the bit 1 and 2 (of $9F22) set to 0.

**Note**: this change to VERA has also been implemented for the X16 emulator (see PR by **MooingLemur**: https://github.com/commanderx16/x16-emulator/pull/470) and has shown the same behavior.

### Analysis and research into VERA inner workings

Analysis of (parts of) VERA's inner workings has been performed in order to determine what would be needed to create this feature and what the effects would be on the other parts of VERA. The diagrams below show the (visual) results of the research:

![VERA_diagrams-vram_if v](https://user-images.githubusercontent.com/17767704/215263120-dc81c8c6-4151-4117-8ed5-6701f725584c.png)
![VERA_diagrams top v_with_multibyte_write_and_copy](https://user-images.githubusercontent.com/17767704/215287287-29d9df7a-f588-4155-8129-8940f19002fa.png)

