### PR TITLE
Fix sprite collisions; bus timings; sprite budget

### DIFF
--- a/fpga/source/graphics/sprite_renderer.v
+++ b/fpga/source/graphics/sprite_renderer.v
@@ -325,7 +325,7 @@ module sprite_renderer(
     // Determine collision for the current pixel
     wire [3:0] collision =
         linebuf_idx_r < 'd640 &&
-        (!pixel_is_transparent && sprite_collision_mask_r != 4'b0) ? (linebuf_rddata[15:12] & ~sprite_collision_mask_r) : 4'b0;
+        (!pixel_is_transparent && sprite_collision_mask_r != 4'b0) ? (linebuf_rddata[15:12] & sprite_collision_mask_r) : 4'b0;
 
     // Render state machine
     always @* begin

--- a/fpga/source/top.v
+++ b/fpga/source/top.v
@@ -211,24 +211,14 @@ module top(
     reg [4:0] rdaddr_r;
     reg [4:0] wraddr_r;
     reg [7:0] wrdata_r;
-    reg [4:0] wraddrp_r;
-    reg [7:0] wrdatap_r;
-    reg [4:0] wraddrn_r;
-    reg [7:0] wrdatan_r;
 
-    always @(posedge clk) begin
-        wraddrp_r <= extbus_a;
-        wrdatap_r <= extbus_d;
-    end
-    always @(negedge clk) begin
-        wraddrn_r <= extbus_a;
-        wrdatan_r <= extbus_d;
-    end
     always @(negedge bus_write) begin
-        wraddr_r <= clk ? wraddrn_r : wraddrp_r;
-        wrdata_r <= clk ? wrdatan_r : wrdatap_r;
+        wrdata_r <= extbus_d;
     end
-    always @(negedge bus_read) begin
+    always @(posedge bus_write) begin
+        wraddr_r <= extbus_a;
+    end
+    always @(posedge bus_read) begin
         rdaddr_r <= extbus_a;
     end
 
@@ -757,13 +747,13 @@ module top(
         // Interface 1 - 32-bit read only
         .if1_addr(l0_addr),
         .if1_rddata(l0_rddata),
-        .if1_strobe(l0_strobe),
+        .if1_strobe(l0_strobe & l0_enabled_r),
         .if1_ack(l0_ack),
 
         // Interface 2 - 32-bit read only
         .if2_addr(l1_addr),
         .if2_rddata(l1_rddata),
-        .if2_strobe(l1_strobe),
+        .if2_strobe(l1_strobe & l1_enabled_r),
         .if2_ack(l1_ack),
 
         // Interface 3 - 32-bit read only

--- a/fpga/source/vera_module.sdc
+++ b/fpga/source/vera_module.sdc
@@ -1,7 +1,17 @@
 # 25MHz system clock
 create_clock -name {clk25} -period 40 [get_ports clk25]
 
-# Define clock domains to be independent
-set_clock_groups -group [get_clocks clk25] -asynchronous
+#create_clock -name {wrclk} -period 125 [get_pins -hierarchical wraddr_r/clock]
+#create_clock -name {rdclk} -period 125 [get_pins rdaddr_r/clock]
+#create_clock -name {buscs} -period 125 [get_ports extbus_cs_n]
+create_clock -name {buswr} -period 125 [get_ports extbus_wr_n]
+create_clock -name {busrd} -period 125 [get_ports extbus_rd_n]
+#set_input_delay -clock [get_clocks buswr] -10 -clock_fall [get_ports {extbus_d[0] extbus_d[1] extbus_d[2] extbus_d[3] extbus_d[4] extbus_d[5] extbus_d[6] extbus_d[7]}]
+#set_clock_latency 10 -source -late [get_clocks buswr]
+set_clock_latency 10 -source -early [get_clocks buswr]
+set_clock_latency 10 -source -early [get_clocks busrd]
 
-set_output_delay 10 -clock [get_clocks clk25] [get_ports {vga_r[0] vga_r[1] vga_r[2] vga_r[3] vga_g[0] vga_g[1] vga_g[2] vga_g[3] vga_b[0] vga_b[1] vga_b[2] vga_b[3] vga_hsync vga_vsync}]
+# Define clock domains to be independent
+set_clock_groups -group [get_clocks clk25] -group [get_clocks {buscs buswr busrd}] -asynchronous
+
+set_output_delay -clock [get_clocks clk25] 10 [get_ports {vga_r[0] vga_r[1] vga_r[2] vga_r[3] vga_g[0] vga_g[1] vga_g[2] vga_g[3] vga_b[0] vga_b[1] vga_b[2] vga_b[3] vga_hsync vga_vsync}]


### PR DESCRIPTION
This PR contains three minor changes:

1. A fix to the sprite collision logic for issue #31 
2. A bus timing improvement for more reliable functionality at 10MHz (still not working at 12MHz)
3. An adjustment to the layer memory access strobes to reduce VRAM arbitration when one layer is disabled (increases the available per-scanline cycles for rendering sprites).

All changes have undergone a few weeks of testing on both my mini-ITX hardware and the official X16 proto3 hardware, across multiple software programs. No issues were noted during this time.