### PR TITLE
Fix PCM volume scaling

### DIFF
--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -213,8 +213,8 @@ module pcm(
     reg signed [22:0] left_scaled_r, right_scaled_r;
 
     always @(posedge clk) begin
-        left_scaled_r  <= left_output_r  * {volume_log, 1'b0};
-        right_scaled_r <= right_output_r * {volume_log, 1'b0};
+        left_scaled_r  <= left_output_r  * volume_log * 2;
+        right_scaled_r <= right_output_r * volume_log * 2;
     end
 
     assign left_audio  = left_scaled_r;

--- a/fpga/source/audio/pcm.v
+++ b/fpga/source/audio/pcm.v
@@ -189,32 +189,32 @@ module pcm(
     // Volume
     //////////////////////////////////////////////////////////////////////////
 
-    // Logarithmic volume conversion (2.2dB per step)
-    reg signed [7:0] volume_log;
+    // Logarithmic volume conversion (2.26dB per step)
+    reg signed [8:0] volume_log;
     always @* case (volume)
-        4'd0:  volume_log = 8'd0;
-        4'd1:  volume_log = 8'd1;
-        4'd2:  volume_log = 8'd2;
-        4'd3:  volume_log = 8'd3;
-        4'd4:  volume_log = 8'd4;
-        4'd5:  volume_log = 8'd5;
-        4'd6:  volume_log = 8'd6;
-        4'd7:  volume_log = 8'd8;
-        4'd8:  volume_log = 8'd11;
-        4'd9:  volume_log = 8'd14;
-        4'd10: volume_log = 8'd18;
-        4'd11: volume_log = 8'd23;
-        4'd12: volume_log = 8'd30;
-        4'd13: volume_log = 8'd38;
-        4'd14: volume_log = 8'd49;
-        4'd15: volume_log = 8'd64;
+        4'd0:  volume_log = 9'd0;
+        4'd1:  volume_log = 9'd2;
+        4'd2:  volume_log = 9'd4;
+        4'd3:  volume_log = 9'd6;
+        4'd4:  volume_log = 9'd8;
+        4'd5:  volume_log = 9'd10;
+        4'd6:  volume_log = 9'd12;
+        4'd7:  volume_log = 9'd16;
+        4'd8:  volume_log = 9'd21;
+        4'd9:  volume_log = 9'd27;
+        4'd10: volume_log = 9'd35;
+        4'd11: volume_log = 9'd45;
+        4'd12: volume_log = 9'd59;
+        4'd13: volume_log = 9'd76;
+        4'd14: volume_log = 9'd99;
+        4'd15: volume_log = 9'd128;
     endcase
 
     reg signed [22:0] left_scaled_r, right_scaled_r;
 
     always @(posedge clk) begin
-        left_scaled_r  <= left_output_r  * volume_log * 2;
-        right_scaled_r <= right_output_r * volume_log * 2;
+        left_scaled_r  <= left_output_r  * volume_log;
+        right_scaled_r <= right_output_r * volume_log;
     end
 
     assign left_audio  = left_scaled_r;


### PR DESCRIPTION
Vector concatenation somehow messed up the sign extension on the PCM output. This fixes distortions on low volumes.