### PR TITLE
Make VGA sync polarity negative.

### DIFF
--- a/fpga/source/video/video_vga.v
+++ b/fpga/source/video/video_vga.v
@@ -82,8 +82,8 @@ module video_vga(
             vga_r <= 4'd0;
             vga_g <= 4'd0;
             vga_b <= 4'd0;
-            vga_hsync <= 0;
-            vga_vsync <= 0;
+            vga_hsync <= 1;
+            vga_vsync <= 1;
 
         end else begin
             if (active_r[1]) begin
@@ -96,8 +96,8 @@ module video_vga(
                 vga_b <= 4'd0;
             end
 
-            vga_hsync <= hsync_r[1];
-            vga_vsync <= vsync_r[1];
+            vga_hsync <= ~hsync_r[1];
+            vga_vsync <= ~vsync_r[1];
         end
     end
 


### PR DESCRIPTION
Fix for #38 - Sync polarity negative instead of positive. This was tested by Adrian Black on a number of monitors and several that were previously unable to sync could now do so.